### PR TITLE
updating run_wat_to_link to source venv spark submit not local

### DIFF
--- a/bash_scripts/run_wat_to_link.sh
+++ b/bash_scripts/run_wat_to_link.sh
@@ -29,8 +29,8 @@ export PYSPARK_DRIVER_PYTHON="$VENV_PATH/bin/python"
 
 
 # Run the Spark job
-# TODO: Change test_wat.txt -> "all_wat_$CRAWL.txt" left for local testing purposes
-/opt/spark/bin/spark-submit \
+# TODO: Change test_wat.txt -> "all_wat_${CRAWL}.txt" left for local testing purposes
+"$VENV_PATH"/bin/spark-submit \
   --py-files "$PROJECT_ROOT/tgrag/cc-scripts/sparkcc.py" \
   "$PROJECT_ROOT/tgrag/cc-scripts/wat_extract_links.py" \
   "$INPUT_DIR/test_wat.txt" \


### PR DESCRIPTION
Quick fix, previous run_wat_link.sh was missing the venv spark.submit and was using my local machine's